### PR TITLE
modify japanese setting value into "ja-JP"

### DIFF
--- a/source/artyom.ts
+++ b/source/artyom.ts
@@ -74,7 +74,7 @@ export default class Artyom {
             // Italian
             "it-IT" : ["Google italiano","it-IT","it_IT"],
             // Japanese
-            "jp-JP": ["Google 日本人","ja-JP","ja_JP"],
+            "ja-JP": ["Google 日本人","ja-JP","ja_JP"],
             // English USA
             "en-US": ["Google US English","en-US","en_US"],
             // English UK


### PR DESCRIPTION
Japanese setting is "ja-JP" according to README.md, but implementation uses "jp-JP". Japanese recognition does not work in config "jp-JP" .
This PR fix this issue. "ja-JP" is correct.

Detail: https://github.com/mamewotoko/artyom.js/issues/1