### PR TITLE
Fixed Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Artyom provides **complete** support for the following languages. Every language
 |<img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-german.png" alt="Supported language"/>| Deutsch (German) | de-DE |
 | <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-italy.png" alt="Supported language"/> | Italiano |it-IT |
 | <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-france.png" alt="Supported language"/> | Français |fr-FR |
-| <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-japan.png" alt="Supported language"/> | Japanese 日本人 | ja-JP |
+| <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-japan.png" alt="Supported language"/> | Japanese 日本語 | ja-JP |
 | <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-russia.png" alt="Supported language"/> | Russian | ru-RU |
 | <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-brasil.png" alt="Supported language"/> | Brazil | pt-PT |
 | <img src="https://raw.githubusercontent.com/sdkcarlos/sdkcarlos.github.io/master/sites/artyom-resources/images/flag-netherlands.png" alt="Supported language"/> | Dutch (netherlands)| nl-NL |


### PR DESCRIPTION
As mentioned in https://github.com/sdkcarlos/artyom.js/issues/25,

In the languages section, Japanese is written as "日本人" which means "Japan people", proof:
![image](https://user-images.githubusercontent.com/45014214/100494107-4e6bfa80-310c-11eb-993d-aa08a22bbcd7.png)

I changed it to "日本語" which means "Japan language", proof:
![image](https://user-images.githubusercontent.com/45014214/100494115-70fe1380-310c-11eb-863d-0c191b405559.png)