### PR TITLE
Added .setVoice() to override default

### DIFF
--- a/build/artyom.js
+++ b/build/artyom.js
@@ -13,7 +13,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 /// <reference path="artyom.d.ts" />
 // Remove "export default " keywords if willing to build with `npm run artyom-build-window`
-var Artyom = (function () {
+var Artyom = /** @class */ (function () {
     // Triggered at the declaration of 
     function Artyom() {
         this.ArtyomCommands = [];
@@ -25,7 +25,7 @@ var Artyom = (function () {
             // Italian
             "it-IT": ["Google italiano", "it-IT", "it_IT"],
             // Japanese
-            "jp-JP": ["Google 日本人", "ja-JP", "ja_JP"],
+            "ja-JP": ["Google 日本人", "ja-JP", "ja_JP"],
             // English USA
             "en-US": ["Google US English", "en-US", "en_US"],
             // English UK
@@ -89,7 +89,8 @@ var Artyom = (function () {
             speaking: false,
             obeying: true,
             soundex: false,
-            name: null
+            name: null,
+            voice: null,
         };
         this.ArtyomGarbageCollection = [];
         this.ArtyomFlags = {
@@ -901,6 +902,9 @@ var Artyom = (function () {
                 _this.hey(resolve, reject);
             });
         }
+        if (config.hasOwnProperty("voice")) {
+            _this.setVoice(config.voice);
+        }
         return Promise.resolve(true);
     };
     /**
@@ -1060,6 +1064,23 @@ var Artyom = (function () {
      */
     Artyom.prototype.getGarbageCollection = function () {
         return this.ArtyomGarbageCollection;
+    };
+    /**
+     *  Set a voice of the browser by it's voice name
+     *  You can find a list of available voices using .getVoices()
+     *
+     * @param voiceName
+     */
+    Artyom.prototype.setVoice = function (voiceName) {
+        this.debug('Setting voice to ' + voiceName);
+        var availableVoices = this.getVoices();
+        var newVoice = availableVoices.filter(function (v) { return v.name === voiceName; })[0];
+        if (!newVoice) {
+            console.warn("The provided voice " + voiceName + " isn't available, ignoring setVoice command");
+            return;
+        }
+        this.ArtyomProperties.voice = voiceName;
+        this.ArtyomVoice = newVoice;
     };
     /**
      *  Retrieve a single voice of the browser by it's language code.
@@ -1357,6 +1378,7 @@ var Artyom = (function () {
      * @returns {undefined}
      */
     Artyom.prototype.talk = function (text, actualChunk, totalChunks, callbacks) {
+        var _this_1 = this;
         var _this = this;
         var msg = new SpeechSynthesisUtterance();
         msg.text = text;
@@ -1369,6 +1391,15 @@ var Artyom = (function () {
             if (callbacks.hasOwnProperty("lang")) {
                 availableVoice = _this.getVoice(callbacks.lang);
             }
+        }
+        if (this.ArtyomProperties.voice) {
+            var availableVoices = this.getVoices();
+            var newVoice = availableVoices.filter(function (v) { return v.name === _this_1.ArtyomProperties.voice; })[0];
+            if (!newVoice) {
+                console.warn("The provided voice " + this.ArtyomProperties.voice + " isn't available, using default for " + _this.ArtyomProperties.lang);
+                return;
+            }
+            availableVoice = newVoice;
         }
         // If is a mobile device, provide only the language code in the lang property i.e "es_ES"
         if (this.Device.isMobile) {

--- a/source/artyom.d.ts
+++ b/source/artyom.d.ts
@@ -55,6 +55,7 @@ interface ArtyomProperties {
     obeying?: boolean;
     soundex?: boolean;
     name?: string;
+    voice?: string;
 }
 
 interface PromptOptions {

--- a/source/artyom.ts
+++ b/source/artyom.ts
@@ -140,7 +140,8 @@ export default class Artyom {
             speaking: false,
             obeying: true,
             soundex: false,
-            name: null
+            name: null,
+            voice: null,
         };
 
         this.ArtyomGarbageCollection = [];
@@ -1095,6 +1096,10 @@ export default class Artyom {
             });
         }
 
+        if (config.hasOwnProperty("voice")) {
+            _this.setVoice(config.voice)
+        }
+
         return Promise.resolve(true);
     }
 
@@ -1273,6 +1278,26 @@ export default class Artyom {
      */
     getGarbageCollection() {
         return this.ArtyomGarbageCollection;
+    }
+
+
+
+    /**
+     *  Set a voice of the browser by it's voice name
+     *  You can find a list of available voices using .getVoices()
+     *
+     * @param voiceName
+     */
+    setVoice(voiceName: string) {
+        this.debug('Setting voice to ' + voiceName)
+        const availableVoices = this.getVoices()
+        const newVoice = availableVoices.filter(v => v.name === voiceName)[0]
+        if (!newVoice) {
+            console.warn(`The provided voice ${voiceName} isn't available, ignoring setVoice command` );
+            return
+        }
+        this.ArtyomProperties.voice = voiceName
+        this.ArtyomVoice = newVoice;
     }
 
     /**
@@ -1620,7 +1645,7 @@ export default class Artyom {
         msg.text = text;
         msg.volume = this.ArtyomProperties.volume;
         msg.rate = this.ArtyomProperties.speed;
-
+        
         // Select the voice according to the selected
         let availableVoice = _this.getVoice(_this.ArtyomProperties.lang);
 
@@ -1629,6 +1654,16 @@ export default class Artyom {
             if(callbacks.hasOwnProperty("lang")){
                 availableVoice = _this.getVoice(callbacks.lang);
             }
+        }
+
+        if (this.ArtyomProperties.voice) {
+            const availableVoices = this.getVoices()
+            const newVoice = availableVoices.filter(v => v.name === this.ArtyomProperties.voice)[0]
+            if (!newVoice) {
+                console.warn(`The provided voice ${this.ArtyomProperties.voice} isn't available, using default for ${_this.ArtyomProperties.lang}` );
+                return
+            }
+            availableVoice = newVoice
         }
         
         // If is a mobile device, provide only the language code in the lang property i.e "es_ES"


### PR DESCRIPTION
Love the library! The one thing I needed was the ability to override the default language voice, it seemed pretty restrictive before. The way I'm now using this is like:

```js
artyom
        .initialize({
          lang: "en-US",
          continuous: true,
          debug: true, 
          listen: true,
          name: "Archimedes",
        })
        .then(() => {
          artyom.setVoice("Google UK English Female");
          // artyom.setVoice("Tessa");
          // artyom.setVoice("Veena");
        });
```

I found that trying to set it in the initialize function wasn't working because `getVoices` wasn't populated yet. putting it afterwards, though, seemed to work.

Let me know if you want more documentation or cleanup, happy to hop back in and tighten this up.